### PR TITLE
Add maths engine and session checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A friendly and interactive maths helper bot for Key Stage 2 students (Years 5 & 
 - Topic-based question selection
 - Step-by-step problem-solving guidance
 - Warm and encouraging teaching style
+- Uses **SymPy** to safely check students' answers
 
 ## Setup
 

--- a/maths_engine.py
+++ b/maths_engine.py
@@ -1,0 +1,65 @@
+import re
+from sympy import sympify
+
+NUMBER_WORDS = {
+    'zero': 0,
+    'one': 1,
+    'two': 2,
+    'three': 3,
+    'four': 4,
+    'five': 5,
+    'six': 6,
+    'seven': 7,
+    'eight': 8,
+    'nine': 9,
+    'ten': 10,
+    'eleven': 11,
+    'twelve': 12,
+    'thirteen': 13,
+    'fourteen': 14,
+    'fifteen': 15,
+    'sixteen': 16,
+    'seventeen': 17,
+    'eighteen': 18,
+    'nineteen': 19,
+    'twenty': 20,
+}
+
+def evaluate_expression(expr: str):
+    """Safely evaluate a mathematical expression using sympy."""
+    try:
+        return float(sympify(expr))
+    except Exception:
+        return None
+
+def parse_number(text: str):
+    """Extract a numeric value from a piece of text."""
+    if not text:
+        return None
+    lowered = text.lower()
+    for word, value in NUMBER_WORDS.items():
+        if re.search(rf"\b{word}\b", lowered):
+            return float(value)
+    # Try direct evaluation
+    cleaned = re.sub(r"[^0-9\-+*/.]+", " ", lowered)
+    result = evaluate_expression(cleaned)
+    if result is not None:
+        return result
+    # Fallback to first number in the text
+    m = re.search(r"-?\d+(?:\.\d+)?", lowered)
+    if m:
+        try:
+            return float(m.group())
+        except ValueError:
+            pass
+    return None
+
+def check_answer(user_answer: str, expected_answer: str, tolerance: float = 1e-2) -> bool:
+    """Return True if the user's answer matches the expected answer."""
+    user_val = parse_number(user_answer)
+    expected_val = parse_number(expected_answer)
+    if user_val is not None and expected_val is not None:
+        return abs(user_val - expected_val) <= tolerance
+    if user_answer and expected_answer:
+        return user_answer.strip().lower() == expected_answer.strip().lower()
+    return False

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ openai==1.12.0
 python-dotenv==1.0.1
 sounddevice==0.4.6
 numpy==1.26.4
+sympy==1.12


### PR DESCRIPTION
## Summary
- create a helper module `maths_engine.py`
- set `app.secret_key` and import `session`
- use `maths_engine.check_answer` when users reply
- remember question answers in the session
- add `sympy` dependency and document it

## Testing
- `python -m py_compile main.py maths_engine.py`

------
https://chatgpt.com/codex/tasks/task_e_68442f97a56c8326bef73506008d756a